### PR TITLE
Fix case sensitive inclusion of Arduino.h

### DIFF
--- a/ZeroPi/src/ZeroPi.h
+++ b/ZeroPi/src/ZeroPi.h
@@ -1,7 +1,7 @@
 #ifndef ZEROPI_H
 #define ZEROPI_H
 
-#include "arduino.h"
+#include "Arduino.h"
 
 #define FORCE_INLINE __INLINE
 


### PR DESCRIPTION
On linux i could not run the Stepper Motor samples without this change.
